### PR TITLE
Remove flickering of the notification

### DIFF
--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/service/NotificationHandler.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/service/NotificationHandler.kt
@@ -82,7 +82,6 @@ class NotificationHandler(private val service: MusicService) : BroadcastReceiver
                 .setContentIntent(contentIntent)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                .setProgress(0, 0, true)
         service.startForeground(NotificationId, notificationBuilder.build())
         handler.postDelayed(UpdateLoadingNotificationRunnable, 1000)
     }


### PR DESCRIPTION
Currently the notification progress bar is "flickering" which doesn't look great. I mean the effect that every time bandwidth is reported, the progress bar is set to 0. There's probably a better way than removing the progress bar altogether but I couldn't figure it out.