### PR TITLE
Mega pull request

### DIFF
--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/DaggerComponent.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/DaggerComponent.kt
@@ -4,7 +4,7 @@ import com.github.funkyg.funkytunes.activities.MainActivity
 import com.github.funkyg.funkytunes.network.ChartsFetcher
 import com.github.funkyg.funkytunes.network.UpdateChecker
 import com.github.funkyg.funkytunes.network.SearchHandler
-//import com.github.funkyg.funkytunes.network.PirateBayAdapter
+import com.github.funkyg.funkytunes.network.PirateBayAdapter
 import com.github.funkyg.funkytunes.network.SkyTorrentsAdapter
 import com.github.funkyg.funkytunes.service.MusicService
 import com.github.funkyg.funkytunes.service.NotificationHandler
@@ -19,6 +19,7 @@ interface DaggerComponent {
     fun inject(app: FunkyApplication)
     fun inject(chartsFetcher: ChartsFetcher)
     fun inject(searchHandler: SearchHandler)
+    fun inject(pirateBayAdapter: PirateBayAdapter)
     fun inject(skyTorrentsAdapter: SkyTorrentsAdapter)
     fun inject(updateChecker: UpdateChecker)
     fun inject(musicService: MusicService)

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/DaggerComponent.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/DaggerComponent.kt
@@ -4,7 +4,8 @@ import com.github.funkyg.funkytunes.activities.MainActivity
 import com.github.funkyg.funkytunes.network.ChartsFetcher
 import com.github.funkyg.funkytunes.network.UpdateChecker
 import com.github.funkyg.funkytunes.network.SearchHandler
-import com.github.funkyg.funkytunes.network.PirateBayAdapter
+//import com.github.funkyg.funkytunes.network.PirateBayAdapter
+import com.github.funkyg.funkytunes.network.SkyTorrentsAdapter
 import com.github.funkyg.funkytunes.service.MusicService
 import com.github.funkyg.funkytunes.service.NotificationHandler
 import com.github.funkyg.funkytunes.service.TorrentManager
@@ -18,7 +19,7 @@ interface DaggerComponent {
     fun inject(app: FunkyApplication)
     fun inject(chartsFetcher: ChartsFetcher)
     fun inject(searchHandler: SearchHandler)
-    fun inject(pirateBayAdapter: PirateBayAdapter)
+    fun inject(skyTorrentsAdapter: SkyTorrentsAdapter)
     fun inject(updateChecker: UpdateChecker)
     fun inject(musicService: MusicService)
     fun inject(notificationHandler: NotificationHandler)

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/FunkyModule.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/FunkyModule.kt
@@ -36,4 +36,7 @@ class FunkyModule(private val app: FunkyApplication) {
 
     @Provides
     fun getPirateBayAdapter() = PirateBayAdapter(app)
+
+    @Provides
+    fun getSkyTorrentsAdapter() = SkyTorrentsAdapter(app)
 }

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/Model.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/Model.kt
@@ -1,6 +1,14 @@
 package com.github.funkyg.funkytunes
 
-data class Album(val title: String, val artist: String, val image: Image)
+data class Album(val title: String, val artist: String, val image: Image) {
+	fun getQuery(): String {
+        // Exclude additions like "(Original Motion Picture Soundtrack)" or "(Deluxe Edition)" from
+        // the query.
+        val name = title.split('(', '[', limit = 2)[0]
+        val query = artist + " " + name
+		return query
+	}
+}
 
 data class Song(val name: String, val artist: String?, val image: Image, val duration: Int?)
 

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/activities/MainActivity.kt
@@ -5,12 +5,14 @@ import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
 import android.support.v4.view.MenuItemCompat
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.SearchView
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.util.Log
 import com.github.funkyg.funkytunes.Album
 import com.github.funkyg.funkytunes.BR
 import com.github.funkyg.funkytunes.FunkyApplication
@@ -31,7 +33,12 @@ class MainActivity : BaseActivity(), SearchView.OnQueryTextListener {
     @Inject lateinit var updateChecker: UpdateChecker
     @Inject lateinit var searchHandler: SearchHandler
     private lateinit var binding: ActivityMainBinding
+	private lateinit var searchDebounceHandler: Handler
+	private lateinit var searchDebounceRunnable: Runnable
+	private var oldSearchText = ""
+	private var searchText = ""
     private var searchView: SearchView? = null
+	private val Tag = "MainActivity"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,6 +49,22 @@ class MainActivity : BaseActivity(), SearchView.OnQueryTextListener {
 
         chartsFetcher.fetchAppleAlbumFeed { f -> showAlbums(f) }
         checkUpdates()
+
+		searchDebounceHandler = Handler()
+		searchDebounceRunnable = Runnable {
+			if (searchText != oldSearchText) {
+				if (!searchText.isEmpty()) {
+					doSearchText(searchText)
+				}
+				else {
+					chartsFetcher.fetchAppleAlbumFeed { f -> showAlbums(f) }
+				}
+
+				oldSearchText = searchText
+			}
+			searchDebounceHandler.postDelayed(searchDebounceRunnable, 500)
+		}
+		searchDebounceHandler.postDelayed(searchDebounceRunnable, 500)
     }
 
     override fun onServiceConnected() {
@@ -64,6 +87,12 @@ class MainActivity : BaseActivity(), SearchView.OnQueryTextListener {
         binding.progress.visibility = View.GONE
 
     }
+
+	private fun doSearchText(text: String) {
+		SearchHandler(this).search(searchText, { a ->
+			showAlbums(a)
+		})
+	}
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         super.onCreateOptionsMenu(menu)
@@ -100,21 +129,14 @@ class MainActivity : BaseActivity(), SearchView.OnQueryTextListener {
     }
 
     override fun onQueryTextSubmit(query: String): Boolean {
-		return this.onQueryTextChange(query)
+		if(!query.isEmpty()) {
+			doSearchText(query)
+		}
+		return true
 	}
 
     override fun onQueryTextChange(newText: String): Boolean {
-        if (!newText.isEmpty()) {
-            SearchHandler(this).search(newText, { a ->
-                // Dont show outdated results if the query has already changed in between
-                if (newText != searchView?.query.toString()) {
-                    showAlbums(a)
-                }
-            })
-        }
-        else {
-            chartsFetcher.fetchAppleAlbumFeed { f -> showAlbums(f) }
-        }
+		this.searchText = newText
         return true
     }
 

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/activities/MainActivity.kt
@@ -99,7 +99,9 @@ class MainActivity : BaseActivity(), SearchView.OnQueryTextListener {
         }
     }
 
-    override fun onQueryTextSubmit(query: String) = true
+    override fun onQueryTextSubmit(query: String): Boolean {
+		return this.onQueryTextChange(query)
+	}
 
     override fun onQueryTextChange(newText: String): Boolean {
         if (!newText.isEmpty()) {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/PirateBayAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/PirateBayAdapter.kt
@@ -74,6 +74,8 @@ class PirateBayAdapter(context: Context) {
 			}
 
 			volleyQueue.add(request)
+		} else {
+			resultCollector.go()
 		}
     }
 

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SearchHandler.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SearchHandler.kt
@@ -54,6 +54,8 @@ class SearchHandler(val context: Context) {
                 .appendQueryParameter("secret", DISCOGS_API_SECRET)
                 .build()
 
+		Log.i(Tag, uri.toString())
+
         val request = object : StringRequest(Method.GET, uri.toString(), Response.Listener<String> { reply ->
             listener(parseFeed(reply))
         }, Response.ErrorListener { error ->

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SearchResultCollector.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SearchResultCollector.kt
@@ -1,0 +1,75 @@
+package com.github.funkyg.funkytunes.network
+
+import android.util.Log
+import com.android.volley.Request
+import com.frostwire.jlibtorrent.*
+import com.github.funkyg.funkytunes.R
+import java.util.*
+
+/* Torrent search result */
+class SearchResult(val title: String, val magnetLink: String, val torrentUrl: String?, val detailsUrl: String,
+					val size: String, val added: Date?, val seeds: Int, val leechers: Int,
+					var torrentInfo: TorrentInfo?) {
+					}
+
+/*
+ * Collects responses from torrent requests
+ * Calls a callback when all results are complete
+ */
+
+class SearchResultCollector(val torrentListener: (TorrentInfo)->Unit, val magnetListener: (String)->Unit, val errorListener: (Int) -> Unit) {
+	private val Tag = "ResultCollector"
+	private val watchedRequests = arrayListOf<Request<TorrentInfo>>()
+	private var failedRequests = 0
+	private val searchResults = arrayListOf<SearchResult>()
+
+	fun watchRequest(req: Request<TorrentInfo>) {
+		watchedRequests.add(req)
+	}
+
+	private fun getBestResult(): SearchResult {
+		assert(searchResults.size > 0)
+		val eligibleTorrents = searchResults
+		                       .sortedByDescending {r -> r.seeds + r.leechers}
+		Log.i(Tag, "Selecting torrent: ${eligibleTorrents[0].detailsUrl}")
+		return eligibleTorrents[0]
+	}
+
+	private fun checkComplete() {
+		if(watchedRequests.size <= failedRequests + searchResults.size) {
+			if(searchResults.size > 0) {
+				/* Success - got one or more good results */
+				val bestResult = getBestResult()
+				var sent = false
+				bestResult.torrentInfo?.let { ti ->
+					Log.i(Tag, "Starting torrent download")
+					torrentListener(ti)
+					sent = true
+				}
+				if(!sent) {
+					Log.i(Tag, "Starting manget download")
+					magnetListener(bestResult.magnetLink)
+				}
+			} else {
+				Log.w(Tag, "All requests failed")
+				errorListener(R.string.error_no_torrent_found)
+			}
+		} else {
+			val totalCompleted = failedRequests + searchResults.size
+			Log.i(Tag, "${totalCompleted} / ${watchedRequests.size} - ${searchResults.size} usable")
+			for(request in watchedRequests) {
+				Log.i(Tag, "INQUEUE: " + request.getUrl())
+			}
+		}
+	}
+
+	fun addFailed() {
+		failedRequests = failedRequests + 1
+		checkComplete()
+	}
+
+	fun addResult(result: SearchResult) {
+		searchResults.add(result)
+		checkComplete()
+	}
+}

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SearchResultCollector.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SearchResultCollector.kt
@@ -2,6 +2,7 @@ package com.github.funkyg.funkytunes.network
 
 import android.util.Log
 import com.android.volley.Request
+import com.android.volley.toolbox.StringRequest
 import com.frostwire.jlibtorrent.*
 import com.github.funkyg.funkytunes.R
 import java.util.*
@@ -19,12 +20,20 @@ class SearchResult(val title: String, val magnetLink: String, val torrentUrl: St
 
 class SearchResultCollector(val torrentListener: (TorrentInfo)->Unit, val magnetListener: (String)->Unit, val errorListener: (Int) -> Unit) {
 	private val Tag = "ResultCollector"
-	private val watchedRequests = arrayListOf<Request<TorrentInfo>>()
+	private val watchedRequests = arrayListOf<String>()
 	private var failedRequests = 0
 	private val searchResults = arrayListOf<SearchResult>()
 	private var readyToGo = false
 
 	fun watchRequest(req: Request<TorrentInfo>) {
+		watchedRequests.add(req.getUrl())
+	}
+
+	fun watchRequest(req: StringRequest) {
+		watchedRequests.add(req.getUrl())
+	}
+
+	fun watchRequest(req: String) {
 		watchedRequests.add(req)
 	}
 
@@ -65,7 +74,7 @@ class SearchResultCollector(val torrentListener: (TorrentInfo)->Unit, val magnet
 			val totalCompleted = failedRequests + searchResults.size
 			Log.i(Tag, "${totalCompleted} / ${watchedRequests.size} - ${searchResults.size} usable")
 			for(request in watchedRequests) {
-				Log.i(Tag, "INQUEUE: " + request.getUrl())
+				Log.i(Tag, "INQUEUE: " + request)
 			}
 		}
 	}
@@ -81,6 +90,7 @@ class SearchResultCollector(val torrentListener: (TorrentInfo)->Unit, val magnet
 	}
 
 	/* Additional lock - no listeners will be called before go() is called */
+	/* Call it when all the requests have been added in the last adapter */
 	fun go() {
 		readyToGo = true
 		checkComplete()

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SearchResultCollector.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SearchResultCollector.kt
@@ -11,7 +11,19 @@ import java.util.*
 class SearchResult(val title: String, val magnetLink: String, val torrentUrl: String?, val detailsUrl: String,
 					val size: String, val added: Date?, val seeds: Int, val leechers: Int,
 					var torrentInfo: TorrentInfo?) {
-					}
+	private var isFlac = false
+
+	fun score(): Int {
+		val peers = seeds + leechers
+		val torrentAvailableMultiplier = if(torrentInfo == null) 1 else 50
+		val nonFlacMultiplier = if(isFlac) 1 else 2
+
+		return peers * torrentAvailableMultiplier * nonFlacMultiplier
+	}
+	fun flacDetected() {
+		isFlac = true
+	}
+}
 
 /*
  * Collects responses from torrent requests
@@ -40,7 +52,7 @@ class SearchResultCollector(val torrentListener: (TorrentInfo)->Unit, val magnet
 	private fun getBestResult(): SearchResult {
 		assert(searchResults.size > 0)
 		val eligibleTorrents = searchResults
-		                       .sortedByDescending {r -> ((r.seeds + r.leechers) * (if(r.torrentInfo == null) 1 else 50))}
+		                       .sortedByDescending {r -> r.score()}
 		Log.i(Tag, "Selecting torrent: ${eligibleTorrents[0].detailsUrl}")
 		return eligibleTorrents[0]
 	}

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -29,7 +29,7 @@ class SkyTorrentsAdapter(context: Context) {
 
     private val Tag = "SkyTorrentsAdapter"
     private val DOMAINS = arrayOf("https://www.skytorrents.in")
-    private val QUERYURL = "/search/all/ed/1/?l=en_us&q=%s"
+    private val QUERYURL = "/search/all/ss/1/?l=en_us&q=%s"
 
     @Inject lateinit var volleyQueue: RequestQueue
 

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -98,12 +98,14 @@ class SkyTorrentsAdapter(context: Context) {
 							try {
 								Log.i(Tag, "Parsing torrent from URL: " + item.torrentUrl)
 								for (fileNum in 0..fileStorage.numFiles()) {
-									fileName = fileStorage.fileName(fileNum)
-									if(fileName.endsWith(".mp3") || fileName.endswith(".flac") || fileName.endswith(".ogg") || fileName.endswith(".m4a")) {
+									val fileName = fileStorage.fileName(fileNum)
+									if(fileName.endsWith(".mp3") || fileName.endsWith(".flac") || fileName.endsWith(".ogg") || fileName.endsWith(".m4a")) {
 										Log.i(Tag, "Torrent usable: " + item.torrentUrl)
+										if(fileName.endsWith(".flac")) {
+											item.flacDetected()
+										}
 										resultCollector.addResult(item)
 										fileUsable = true
-										break
 									}
 								}
 								if(!fileUsable) {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -67,6 +67,9 @@ class SkyTorrentsAdapter(context: Context) {
 						resultCollector.addFailed()
 					}){
 						override fun parseNetworkResponse(response: NetworkResponse) : Response<TorrentInfo> {
+							if (response.statusCode == 429) {
+                                errorListener(R.string.error_429)
+							}
 							val bytes = response.data
 							if (bytes != null) {
 								val tmp = createTempFile("funkytunes", ".torrent")

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -145,7 +145,7 @@ class SkyTorrentsAdapter(context: Context) {
             }
             torStart = nextTorrentIndex
         }
-        return results.slice(0..5)
+        return results.slice(0..Math.min(5, results.size - 1))
     }
 
     private fun parseHtmlItem(htmlItem: String, prefixDetails: String): SearchResult {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -100,11 +100,13 @@ class SkyTorrentsAdapter(context: Context) {
 								for (fileNum in 0..fileStorage.numFiles()) {
 									val fileName = fileStorage.fileName(fileNum)
 									if(fileName.endsWith(".mp3") || fileName.endsWith(".flac") || fileName.endsWith(".ogg") || fileName.endsWith(".m4a")) {
-										Log.i(Tag, "Torrent usable: " + item.torrentUrl)
+										if(!fileUsable) {
+											Log.i(Tag, "Torrent usable: " + item.torrentUrl)
+											resultCollector.addResult(item)
+										}
 										if(fileName.endsWith(".flac")) {
 											item.flacDetected()
 										}
-										resultCollector.addResult(item)
 										fileUsable = true
 									}
 								}

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -98,7 +98,8 @@ class SkyTorrentsAdapter(context: Context) {
 							try {
 								Log.i(Tag, "Parsing torrent from URL: " + item.torrentUrl)
 								for (fileNum in 0..fileStorage.numFiles()) {
-									if(fileStorage.fileName(fileNum).endsWith(".mp3")) {
+									fileName = fileStorage.fileName(fileNum)
+									if(fileName.endsWith(".mp3") || fileName.endswith(".flac") || fileName.endswith(".ogg") || fileName.endswith(".m4a")) {
 										Log.i(Tag, "Torrent usable: " + item.torrentUrl)
 										resultCollector.addResult(item)
 										fileUsable = true

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -93,12 +93,12 @@ class SkyTorrentsAdapter(context: Context) {
 							val ti = response
 							item.torrentInfo = ti
 
-							val fileStorage = ti.files()
+							val origFiles = ti.origFiles()
 							var fileUsable = false
 							try {
 								Log.i(Tag, "Parsing torrent from URL: " + item.torrentUrl)
-								for (fileNum in 0..fileStorage.numFiles()) {
-									val fileName = fileStorage.fileName(fileNum)
+								for (fileNum in 0..origFiles.numFiles()-1) {
+									val fileName = origFiles.filePath(fileNum)
 									if(fileName.endsWith(".mp3") || fileName.endsWith(".flac") || fileName.endsWith(".ogg") || fileName.endsWith(".m4a")) {
 										if(!fileUsable) {
 											Log.i(Tag, "Torrent usable: " + item.torrentUrl)

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -59,7 +59,16 @@ class SkyTorrentsAdapter(context: Context) {
 					Log.i(Tag, "Trying torrent URL: " + item.torrentUrl)
 					val torrentRequest = object : Request<TorrentInfo>(Method.GET, item.torrentUrl, Response.ErrorListener { error ->
 						Log.i(Tag, "Volley error '" + error.message + "' for URL: " + item.torrentUrl)
-						resultCollector.addFailed()
+						val lowerTitle = item.title.toLowerCase()
+						// Add magnet if it has a supported file format in name
+						if(lowerTitle.indexOf("mp3") != -1 || lowerTitle.indexOf("ogg") != -1 || lowerTitle.indexOf("m4a") != -1) {
+							resultCollector.addResult(item)
+						} else if(lowerTitle.indexOf("flac") != -1) {
+							item.flacDetected()
+							resultCollector.addResult(item)
+						} else {
+							resultCollector.addFailed()
+						}
 					}){
 						override fun parseNetworkResponse(response: NetworkResponse) : Response<TorrentInfo> {
 							if (response.statusCode == 429) {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -1,0 +1,173 @@
+package com.github.funkyg.funkytunes.network
+
+import android.content.Context
+import android.util.Log
+import com.android.volley.RequestQueue
+import com.android.volley.Response
+import com.android.volley.toolbox.StringRequest
+import com.github.funkyg.funkytunes.Album
+import com.github.funkyg.funkytunes.FunkyApplication
+import com.github.funkyg.funkytunes.R
+import java.net.URLEncoder
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.inject.Inject
+import kotlin.collections.ArrayList
+
+/**
+ * Parses SkyTorrents search results from HTML.
+ */
+class SkyTorrentsAdapter(context: Context) {
+
+    private val Tag = "SkyTorrentsAdapter"
+    private val DOMAINS = arrayOf("https://www.skytorrents.in")
+    private val QUERYURL = "/search/all/ed/1/?l=en_us&q=%1"
+
+    @Inject lateinit var volleyQueue: RequestQueue
+
+    init {
+        (context.applicationContext as FunkyApplication).component.inject(this)
+    }
+
+    class SearchResult(val title: String, val torrentUrl: String, val detailsUrl: String,
+                       val size: String, val added: Date?, val seeds: Int, val leechers: Int)
+
+    fun search(album: Album, listener: (String) -> Unit, errorListener: (Int) -> Unit) {
+		search_mirror(0, album, listener, errorListener)
+	}
+
+    fun search_mirror(retry: Int, album: Album, listener: (String) -> Unit, errorListener: (Int) -> Unit) {
+        // Exclude additions like "(Original Motion Picture Soundtrack)" or "(Deluxe Edition)" from
+        // the query.
+        val name = album.title.split('(', '[', limit = 2)[0]
+        val query = album.artist + " " + name
+		if(retry < DOMAINS.size) {
+			val domain = DOMAINS[retry]
+			// Build full URL string
+			val url = String.format(domain + QUERYURL, URLEncoder.encode(query, "UTF-8"))
+			Log.i(Tag, "Trying URL: " + url)
+
+			val request = object : StringRequest(Method.GET, url, Response.Listener<String> { reply ->
+				val parsedResults = parseHtml(reply, domain)
+				when (parsedResults.isEmpty()) {
+					false -> listener(parsedResults.first().torrentUrl)
+					true  -> errorListener(R.string.error_no_torrent_found)
+				}
+			}, Response.ErrorListener { error ->
+				search_mirror(retry + 1, album, listener, errorListener)
+			}) {
+				override fun getHeaders(): MutableMap<String, String> {
+					val headers = HashMap<String, String>()
+					// Spoof Firefox user agent to force a result from The Pirate Bay
+					headers.put("User-agent", "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2")
+					return headers
+				}
+			}
+
+			volleyQueue.add(request)
+		}
+    }
+
+    private fun parseHtml(html: String, prefixDetails: String): List<SearchResult> {
+        // Texts to find subsequently
+        val RESULTS = "<tbody>"
+        val TORRENT = "<td style=\"word-wrap: break-word;\">"
+
+        // Parse the search results from HTML by looking for the identifying texts
+        val results = ArrayList<SearchResult>()
+        val resultsStart = html.indexOf(RESULTS) + RESULTS.length
+
+        var torStart = html.indexOf(TORRENT, resultsStart)
+        while (torStart >= 0) {
+            val nextTorrentIndex = html.indexOf(TORRENT, torStart + TORRENT.length)
+            if (nextTorrentIndex >= 0) {
+                results.add(parseHtmlItem(html.substring(torStart + TORRENT.length, nextTorrentIndex), prefixDetails))
+            } else {
+                results.add(parseHtmlItem(html.substring(torStart + TORRENT.length), prefixDetails))
+            }
+            torStart = nextTorrentIndex
+        }
+        return results
+    }
+
+    private fun parseHtmlItem(htmlItem: String, prefixDetails: String): SearchResult {
+        // Texts to find subsequently
+        val DETAILS = "<a href=\""
+        val DETAILS_END = "\" title=\""
+        val NAME = "\">"
+        val NAME_END = "</a>"
+        val TORRENT_LINK = "<a href=\""
+        val TORRENT_LINK_END = "\" rel=\"nofollow\""
+        val MAGNET_LINK = "<a href=\""
+        val MAGNET_LINK_END = "\" rel=\"nofollow\""
+        val SIZE = "<td class=\"is-hidden-touch\" >"
+        val SIZE_END = "</td>"
+		val NUMFILES = "<td class=\"is-hidden-touch\" style=\"text-align: center;\" >"
+		val NUMFILES_END = "</td>"
+
+        val DATE = "<td class=\"is-hidden-touch\" style=\"text-align: center;\">"
+        val DATE_END = "</td>"
+        val SEEDERS = "<td style=\"text-align: center;\">"
+        val SEEDERS_END = "</td>"
+        val LEECHERS = "<td style=\"text-align: center;\">"
+        val LEECHERS_END = "</td>"
+        val prefixYear = (Date().year + 1900).toString() + " " // Date.getYear() gives the current year - 1900
+        val df1 = SimpleDateFormat("yyyy MM-dd HH:mm", Locale.US)
+        val df2 = SimpleDateFormat("MM-dd yyyy", Locale.US)
+
+        val detailsStart = htmlItem.indexOf(DETAILS) + DETAILS.length
+        var details = htmlItem.substring(detailsStart, htmlItem.indexOf(DETAILS_END, detailsStart))
+        details = prefixDetails + details
+        val nameStart = htmlItem.indexOf(NAME, detailsStart) + NAME.length
+        val name = htmlItem.substring(nameStart, htmlItem.indexOf(NAME_END, nameStart))
+
+        // Torrent link is first
+        val torrentLinkStart = htmlItem.indexOf(TORRENT_LINK, nameStart) + TORRENT_LINK.length
+        val torrentLink = htmlItem.substring(torrentLinkStart, htmlItem.indexOf(TORRENT_LINK_END, torrentLinkStart))
+
+        // Magnet link is second
+        val magnetLinkStart = htmlItem.indexOf(MAGNET_LINK, torrentLinkStart) + MAGNET_LINK.length
+        val magnetLink = htmlItem.substring(magnetLinkStart, htmlItem.indexOf(MAGNET_LINK_END, magnetLinkStart))
+
+        val sizeStart = htmlItem.indexOf(SIZE, magnetLinkStart) + SIZE.length
+        var size = htmlItem.substring(sizeStart, htmlItem.indexOf(SIZE_END, sizeStart))
+        size = size.replace("&nbsp;", " ")
+
+        val numFilesStart = htmlItem.indexOf(NUMFILES, sizeLinkStart) + NUMFILES.length
+        var numFiles = htmlItem.substring(numFilesStart, htmlItem.indexOf(NUMFILES_END, numFilesStart))
+        numFiles = numFiles.replace("&nbsp;", " ")
+
+        val dateStart = htmlItem.indexOf(DATE, numFilesStart) + DATE.length
+        var dateText = htmlItem.substring(dateStart, htmlItem.indexOf(DATE_END, dateStart))
+        dateText = dateText.replace("&nbsp;", " ")
+        var date: Date? = null
+        if (dateText.startsWith("Today")) {
+            date = Date()
+        } else if (dateText.startsWith("Y-day")) {
+            date = Date(Date().time - 86400000L)
+        } else {
+            try {
+                date = df1.parse(prefixYear + dateText)
+            } catch (e: ParseException) {
+                try {
+                    date = df2.parse(dateText)
+                } catch (e1: ParseException) {
+                    // Not parsable at all; just leave it at null
+                }
+
+            }
+        }
+
+        val seedersStart = htmlItem.indexOf(SEEDERS, dateStart) + SEEDERS.length
+        val seedersText = htmlItem.substring(seedersStart, htmlItem.indexOf(SEEDERS_END, seedersStart))
+        val seeders = Integer.parseInt(seedersText)
+
+        val leechersStart = htmlItem.indexOf(LEECHERS, seedersStart) + LEECHERS.length
+        val leechersText = htmlItem.substring(leechersStart, htmlItem.indexOf(LEECHERS_END, leechersStart))
+        val leechers = Integer.parseInt(leechersText)
+
+        return SearchResult(name, magnetLink, details, size, date, seeders, leechers)
+    }
+
+}

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -134,7 +134,7 @@ class SkyTorrentsAdapter(context: Context) {
         var size = htmlItem.substring(sizeStart, htmlItem.indexOf(SIZE_END, sizeStart))
         size = size.replace("&nbsp;", " ")
 
-        val numFilesStart = htmlItem.indexOf(NUMFILES, sizeLinkStart) + NUMFILES.length
+        val numFilesStart = htmlItem.indexOf(NUMFILES, sizeStart) + NUMFILES.length
         var numFiles = htmlItem.substring(numFilesStart, htmlItem.indexOf(NUMFILES_END, numFilesStart))
         numFiles = numFiles.replace("&nbsp;", " ")
 

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/network/SkyTorrentsAdapter.kt
@@ -22,7 +22,7 @@ class SkyTorrentsAdapter(context: Context) {
 
     private val Tag = "SkyTorrentsAdapter"
     private val DOMAINS = arrayOf("https://www.skytorrents.in")
-    private val QUERYURL = "/search/all/ed/1/?l=en_us&q=%1"
+    private val QUERYURL = "/search/all/ed/1/?l=en_us&q=%s"
 
     @Inject lateinit var volleyQueue: RequestQueue
 

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
@@ -10,7 +10,8 @@ import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert
 import com.github.funkyg.funkytunes.Album
 import com.github.funkyg.funkytunes.FunkyApplication
 import com.github.funkyg.funkytunes.R
-import com.github.funkyg.funkytunes.network.PirateBayAdapter
+//import com.github.funkyg.funkytunes.network.PirateBayAdapter
+import com.github.funkyg.funkytunes.network.SkyTorrentsAdapter
 import com.google.common.io.Files
 import java.io.File
 import java.text.NumberFormat
@@ -23,7 +24,8 @@ class TorrentManager(private val context: Context) : AlertListener {
     private val Tag = "TorrentManager"
     private val MAGNET_TIMEOUT_SECONDS = 60
 
-    @Inject lateinit var pirateBayAdapter: PirateBayAdapter
+//  @Inject lateinit var pirateBayAdapter: PirateBayAdapter
+    @Inject lateinit var skyTorrentsAdapter: SkyTorrentsAdapter
     private val sessionManager = SessionManager()
     private var files: List<FileInfo>? = null
     private var currentHash: Sha1Hash? = null
@@ -123,7 +125,7 @@ class TorrentManager(private val context: Context) : AlertListener {
             currentHash = null
         }
 
-        pirateBayAdapter.search(album, { magnet ->
+        skyTorrentsAdapter.search(album, { magnet ->
             Thread({ ->
                 val torrentBytes = sessionManager.fetchMagnet(magnet, MAGNET_TIMEOUT_SECONDS)
                 if (torrentBytes != null) {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
@@ -125,19 +125,26 @@ class TorrentManager(private val context: Context) : AlertListener {
             currentHash = null
         }
 
-        skyTorrentsAdapter.search(album, { magnet ->
+//        pirateBayAdapter.search(album, { magnet ->
+//            Thread({ ->
+//                val torrentBytes = sessionManager.fetchMagnet(magnet, MAGNET_TIMEOUT_SECONDS)
+//                if (torrentBytes != null) {
+//                    val tmp = createTempFile("funkytunes", ".torrent")
+//                    Files.write(torrentBytes, tmp)
+//                    val ti = TorrentInfo(tmp)
+//                    sessionManager.download(ti, context.filesDir)
+//                    tmp.delete()
+//                }
+//                else {
+//                    Log.w(Tag, "Fetching torrent from magnet timed out")
+//                    errorListener(R.string.magnet_download_timeout)
+//                }
+//            }).start()
+//        }, errorListener)
+        skyTorrentsAdapter.search(album, { torrentInfo ->
             Thread({ ->
-                val torrentBytes = sessionManager.fetchMagnet(magnet, MAGNET_TIMEOUT_SECONDS)
-                if (torrentBytes != null) {
-                    val tmp = createTempFile("funkytunes", ".torrent")
-                    Files.write(torrentBytes, tmp)
-                    val ti = TorrentInfo(tmp)
-                    sessionManager.download(ti, context.filesDir)
-                    tmp.delete()
-                }
-                else {
-                    Log.w(Tag, "Fetching torrent from magnet timed out")
-                    errorListener(R.string.magnet_download_timeout)
+                if (torrentInfo != null) {
+                    sessionManager.download(torrentInfo, context.filesDir)
                 }
             }).start()
         }, errorListener)

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
@@ -61,7 +61,7 @@ class TorrentManager(private val context: Context) : AlertListener {
 					handle.prioritizeFiles(getTorrentFiles(handle).map{ Priority.IGNORE }.toTypedArray())
 					files = getTorrentFiles(handle)
 							.withIndex()
-							.filter { p -> (p.value.endsWith(".mp3")  }
+							.filter { p -> (p.value.endsWith(".mp3") || p.value.endswith(".flac") || p.value.endswith(".ogg") || p.value.endswith(".m4a") }
 							.sortedBy { f -> f.value }
 							.map { f -> FileInfo(f.value, f.index, false, File(handle.savePath(), f.value)) }
 					if (files!!.isEmpty()) {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
@@ -10,7 +10,7 @@ import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert
 import com.github.funkyg.funkytunes.Album
 import com.github.funkyg.funkytunes.FunkyApplication
 import com.github.funkyg.funkytunes.R
-//import com.github.funkyg.funkytunes.network.PirateBayAdapter
+import com.github.funkyg.funkytunes.network.PirateBayAdapter
 import com.github.funkyg.funkytunes.network.SkyTorrentsAdapter
 import com.github.funkyg.funkytunes.network.SearchResultCollector
 import com.google.common.io.Files
@@ -25,7 +25,7 @@ class TorrentManager(private val context: Context) : AlertListener {
     private val Tag = "TorrentManager"
     private val MAGNET_TIMEOUT_SECONDS = 60
 
-//    @Inject lateinit var pirateBayAdapter: PirateBayAdapter
+    @Inject lateinit var pirateBayAdapter: PirateBayAdapter
     @Inject lateinit var skyTorrentsAdapter: SkyTorrentsAdapter
     private val sessionManager = SessionManager()
     private var files: List<FileInfo>? = null
@@ -61,7 +61,7 @@ class TorrentManager(private val context: Context) : AlertListener {
 					handle.prioritizeFiles(getTorrentFiles(handle).map{ Priority.IGNORE }.toTypedArray())
 					files = getTorrentFiles(handle)
 							.withIndex()
-							.filter { p -> p.value.endsWith(".mp3") }
+							.filter { p -> (p.value.endsWith(".mp3")  }
 							.sortedBy { f -> f.value }
 							.map { f -> FileInfo(f.value, f.index, false, File(handle.savePath(), f.value)) }
 					if (files!!.isEmpty()) {
@@ -165,8 +165,7 @@ class TorrentManager(private val context: Context) : AlertListener {
 				errorListener)
 
         skyTorrentsAdapter.search(album, resultCollector)
-//        pirateBayAdapter.search(album, this::startTorrent, this::startMagnet, errorListener)
-		resultCollector.go()
+        pirateBayAdapter.search(album, resultCollector)
     }
 
     fun requestSong(position: Int, listener: (File) -> Unit) {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
@@ -61,7 +61,7 @@ class TorrentManager(private val context: Context) : AlertListener {
 					handle.prioritizeFiles(getTorrentFiles(handle).map{ Priority.IGNORE }.toTypedArray())
 					files = getTorrentFiles(handle)
 							.withIndex()
-							.filter { p -> (p.value.endsWith(".mp3") || p.value.endswith(".flac") || p.value.endswith(".ogg") || p.value.endswith(".m4a") }
+							.filter { p -> (p.value.endsWith(".mp3") || p.value.endsWith(".flac") || p.value.endsWith(".ogg") || p.value.endsWith(".m4a")) }
 							.sortedBy { f -> f.value }
 							.map { f -> FileInfo(f.value, f.index, false, File(handle.savePath(), f.value)) }
 					if (files!!.isEmpty()) {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
@@ -12,6 +12,7 @@ import com.github.funkyg.funkytunes.FunkyApplication
 import com.github.funkyg.funkytunes.R
 //import com.github.funkyg.funkytunes.network.PirateBayAdapter
 import com.github.funkyg.funkytunes.network.SkyTorrentsAdapter
+import com.github.funkyg.funkytunes.network.SearchResultCollector
 import com.google.common.io.Files
 import java.io.File
 import java.text.NumberFormat
@@ -24,7 +25,7 @@ class TorrentManager(private val context: Context) : AlertListener {
     private val Tag = "TorrentManager"
     private val MAGNET_TIMEOUT_SECONDS = 60
 
-//  @Inject lateinit var pirateBayAdapter: PirateBayAdapter
+//    @Inject lateinit var pirateBayAdapter: PirateBayAdapter
     @Inject lateinit var skyTorrentsAdapter: SkyTorrentsAdapter
     private val sessionManager = SessionManager()
     private var files: List<FileInfo>? = null
@@ -158,8 +159,14 @@ class TorrentManager(private val context: Context) : AlertListener {
             currentHash = null
         }
 
-        skyTorrentsAdapter.search(album, this::startTorrent, this::startMagnet, errorListener)
-//        pirateBayAdapter.search(album, startTorrent, startMagnet, errorListener)
+		val resultCollector = SearchResultCollector(
+				this::startTorrent,
+				this::startMagnet,
+				errorListener)
+
+        skyTorrentsAdapter.search(album, resultCollector)
+//        pirateBayAdapter.search(album, this::startTorrent, this::startMagnet, errorListener)
+		resultCollector.go()
     }
 
     fun requestSong(position: Int, listener: (File) -> Unit) {

--- a/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
+++ b/app/src/main/kotlin/com/github/funkyg/funkytunes/service/TorrentManager.kt
@@ -98,6 +98,7 @@ class TorrentManager(private val context: Context) : AlertListener {
 				}
 			}
 		} catch (e: Exception) {
+			Log.e(Tag, "This error prevented the torrent file from downloading:")
 			Log.e(Tag, Log.getStackTraceString(e))
 			throw e
 		}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@ By using \' Funkytunes\' or accessing this site you affirm that you are either m
     <string name="accept">Accept</string>
     <string name="leave">Leave</string>
     <string name="error_no_torrent_found">Error: No matching torrent found for album.</string>
+    <string name="error_429">Error: The search engine asks to perform fewer requests.</string>
     <string name="error_torrent_invalid_files">Error: Torrent does not contain any mp3 files.</string>
     <string name="update_available">Update Available</string>
     <string name="download">Download</string>


### PR DESCRIPTION
This is a big one, probably should have been several smaller ones:
- Support for skytorrents (no crashes any more!)
- Rate limiting discogs search requests to 500 ms (closes #17)
- Handle search button to force sending a search request
- Add support for m4a, ogg, flac as these are officially supported on Android 4+

Then I went a little crazy and added ability to run various search engines and select best results based on score. Base score: seeds+leechers. *2 if not FLAC. *50 if torrent file available (no magnet)

I know we were discussing not doing that but it increases number of played albums.